### PR TITLE
support for more number types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SpeedMapping"
 uuid = "f1835b91-879b-4a3f-a438-e4baacf14412"
 authors = ["Nicolas Lepage-Saucier <42039487+nicolasLepageSaucier@users.noreply.github.com> and contributors"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 AccurateArithmetic = "22286c92-06ac-501d-9306-4abd417d9753"


### PR DESCRIPTION
hi, i saw your package and i liked all its integrated functionality. i like the sheer amount of options, but the number type was restricted. what i did in this pull request is parametrize the state struct and some numbers, so that a vector of real (but not integer) types could be passed. this PR allows:
- Support for bigfloats
```julia
using SpeedMapping
#from the tests
function g!(∇,x) # Rosenbrock gradient
	for i ∈ 1:Int(length(x)/2)
		∇[2i] = -200 * (x[2i - 1]^2 - x[2i])
		∇[2i - 1] =  400 * (x[2i - 1]^2 - x[2i]) * x[2i - 1] + 2(x[2i - 1] - 1)
	end
	return nothing
end

julia> speedmapping(zeros(BigFloat,2); g!)
(minimizer = BigFloat[0.9999999967128252719554743475763374899453005543444624975310140452844726450899613, 0.999999993412496602610532663273102833050857594721523559810823871161204301983301], maps = 101, f_calls = 0, converged = true, norm_∇ = 2.941094184014726099590694794207309881747973925817252456900600308780949281904313e-09)
```
- use of Measurement types:
```julia
using Measurements
v = [0.0 ± 0.001 for i in 1:2]

julia> speedmapping(v;g!)
(minimizer = Measurement{Float64}[0.999999997 ± 5.5e-8, 0.99999999 
± 1.1e-7], maps = 101, f_calls = 0, converged = true, norm_∇ = 2.9e-9 ± 4.9e-8)
```

- support for AD via ForwardDiff.jl
```julia

using ForwardDiff, FiniteDifferences

ff(z) = speedmapping(z;g!).minimizer

#using #BigFloat here because the errors are small
#note: the PR isnt required to calculate the jacobian with FiniteDifferences, but it is useful to verify the result obtained with ForwardDiff
julia> FiniteDifferences.jacobian(central_fdm(5, 1),ff,zeros(BigFloat,2))[1]
2×2 Matrix{BigFloat}:
 8.11128e-07  -5.49932e-05
 1.6255e-06   -0.000110206

julia> ForwardDiff.jacobian(ff,[0.0,0.0])
2×2 Matrix{Float64}:
 8.11128e-7  -5.49931e-5
 1.6255e-6   -0.000110206
```