### PR TITLE
Remove DocumenterTools as a dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "0.4.0"
 
 [deps]
 AccurateArithmetic = "22286c92-06ac-501d-9306-4abd417d9753"
-DocumenterTools = "35a29f4d-8980-5a13-9543-d66fff28ecb8"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"
@@ -13,7 +12,6 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 AccurateArithmetic = "0.3"
-DocumenterTools = "0.1"
 ForwardDiff = "^0.10.18"
 julia = "1.6"
 MuladdMacro = "0.2"


### PR DESCRIPTION
As far as I can tell, it's not being used, and it causes unnecessary problems for dependencies: https://github.com/JuliaDocs/DocumenterTools.jl/issues/80